### PR TITLE
Add simple string indexing (and added string indexing test cases)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 *.out
 *.wasm
+*.exe

--- a/gorilla/eval/eval.go
+++ b/gorilla/eval/eval.go
@@ -395,6 +395,8 @@ func evalIndexExpression(left, index object.Object) object.Object {
 	switch {
 	case left.Type() == object.ARRAY && index.Type() == object.INTEGER:
 		return evalArrayIndexExpression(left, index)
+	case left.Type() == object.STRING && index.Type() == object.INTEGER:
+		return evalStringIndexExpression(left, index)
 	default:
 		return NewError("[Line %d] Cannot perform index operation: %s[%s]", left.Line()+1, left.Type(), index.Type())
 	}
@@ -410,6 +412,19 @@ func evalArrayIndexExpression(array, index object.Object) object.Object {
 	}
 
 	return arrayObject.Value[idx]
+}
+
+func evalStringIndexExpression(str, index object.Object) object.Object {
+	stringObject := str.(*object.String)
+	idx := index.(*object.Integer).Value
+	max := int64(len(stringObject.Value) - 1)
+
+	if idx < 0 || idx > max {
+		return NewError("[Line %d] Array index out of range", stringObject.Line()+1)
+	}
+
+	retString := object.NewString(string(stringObject.Value[idx]), stringObject.Line())
+	return retString // stringObject.Value[idx]
 }
 
 func evalIfExpression(ie *ast.IfExpression, env *object.Environment) object.Object {

--- a/gorilla/eval/eval_test.go
+++ b/gorilla/eval/eval_test.go
@@ -193,6 +193,22 @@ addTwo(2);`
 	testIntegerObject(t, testEval(input), 4)
 }
 
+func TestStringIndexing(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`"Hello"[1]`, "e"},
+		{`"Wowzers"[5]`, "r"},
+		{`let str = "Lorem ipsum dolor sit amet."; let str = "padding" + str + "padding"; str[19]`, "d"},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		testStringObject(t, evaluated, tt.expected)
+	}
+}
+
 func testBooleanObject(t *testing.T, obj object.Object, expected bool) bool {
 	result, ok := obj.(*object.Boolean)
 	if !ok {
@@ -224,6 +240,19 @@ func testIntegerObject(t *testing.T, obj object.Object, expected int64) bool {
 func testNullObject(t *testing.T, obj object.Object) bool {
 	if obj != NULL {
 		t.Errorf("object is not NULL. got=%T (%+v)", obj, obj)
+		return false
+	}
+	return true
+}
+
+func testStringObject(t *testing.T, obj object.Object, expected string) bool {
+	result, ok := obj.(*object.String)
+	if !ok {
+		t.Errorf("object is not String. got=%t (%+v)", obj, obj)
+		return false
+	}
+	if result.Value != expected {
+		t.Errorf("object has wrong value. got=%s, expected %s", result.Value, expected)
 		return false
 	}
 	return true


### PR DESCRIPTION
Title really says it all.

Just like arrays have indexing, strings do too now.
```py
display("Expects 'e'")
display("Hello"[1]) # Expects "e"

display("Expects 'r'")
display("Wowzers"[5]) # Expects "r"

display("Expects 'd'")
let str = "Lorem ipsum dolor sit amet.";
let str = "padding" + str + "padding";
display(str[19]) # Expects "d"
```
Output:
![image](https://user-images.githubusercontent.com/29130894/105816840-66c88c00-5f7a-11eb-88cd-c54540d9548b.png)

Continues to keep old tests working, and passes my tests
![image](https://user-images.githubusercontent.com/29130894/105816976-9d9ea200-5f7a-11eb-8875-66a1a4805940.png)

Once I found where I needed to modify stuff, Go was a relatively ok language to code in. Most of my code was just copy/pasting and modifying to what I needed to modify to get things working. I did have a lot of trouble with this part:
```go
retString := object.NewString(string(stringObject.Value[idx]), stringObject.Line())
return retString // stringObject.Value[idx]
```
because I don't think I should be creating a NewString object, but it at least works I guess.

# Note:
This PR also adds `*.exe` to the `.gitignore` file. If you don't want that change, remove that part.