### PR TITLE
Add error & return checking for while loop

### DIFF
--- a/gorilla/eval/eval.go
+++ b/gorilla/eval/eval.go
@@ -198,6 +198,13 @@ func evalWhileExpression(we *ast.WhileExpression, env *object.Environment) objec
 		} else {
 			break
 		}
+
+		if isError(result) {
+			return result
+		}
+		if isReturn(result) {
+			return result
+		}
 	}
 
 	if result != nil {
@@ -487,6 +494,13 @@ func IsTruthy(obj object.Object) bool {
 func isError(obj object.Object) bool {
 	if obj != nil {
 		return obj.Type() == object.ERROR
+	}
+	return false
+}
+
+func isReturn(obj object.Object) bool {
+	if obj != nil {
+		return obj.Type() == object.RETURN
 	}
 	return false
 }


### PR DESCRIPTION
Allows errors to be caught when there are errors inside of a `while` loop.

If there is an explicit `return value` statement, that stops the loop too

All tests pass (I didn't make any new tests)
![image](https://user-images.githubusercontent.com/29130894/105959092-15370480-6041-11eb-9bb3-c2dbdc373019.png)
