### PR TITLE
Add .toStr() method to all data types, except booleans & null

### DIFF
--- a/gorilla/object/builtins.go
+++ b/gorilla/object/builtins.go
@@ -64,7 +64,8 @@ func init() {
 	IntAttrs = map[string]Object{
 		"toStr": &Builtin{
 			Fn: func(self Object, line int, args ...Object) Object {
-				return NewString(strconv.Itoa(int(self.(*Integer).Value)), line+1)
+				// return NewString(strconv.Itoa(int(self.(*Integer).Value)), line+1)
+				return NewString(self.(*Integer).Inspect(), line + 1)
 			},
 		}}
 
@@ -82,6 +83,11 @@ func init() {
 					return NewError("[Line %d] Cannot parse to Int: '%s'", line+1, k)
 				}
 				return NewInt(int64(val), line)
+			},
+		},
+		"toStr": &Builtin{
+			Fn: func(self Object, line int, args ...Object) Object {
+				return NewString(self.(*String).Inspect(), line + 1)
 			},
 		},
 	}
@@ -107,6 +113,11 @@ func init() {
 					return NewError("[Line %d] Cannot shift empty array", line+1)
 				}
 				return self.(*Array).PopFirst()
+			},
+		},
+		"toStr": &Builtin{
+			Fn: func(self Object, line int, args ...Object) Object {
+				return NewString(self.(*Array).Inspect(), line + 1)
 			},
 		},
 	}


### PR DESCRIPTION
The problem with this is that booleans & null don't have a `.toStr()` property, and I don't know how to add them, if that's even possible. Another way I thought of doing this is to maybe make a `str(anyObject)` function, so let me know if that'd be the preferred way. I just added `.toStr()` since that was the one already used by `int`s

Passes all tests, as expected
![image](https://user-images.githubusercontent.com/29130894/105958985-efa9fb00-6040-11eb-9edb-3e0d3e7d3383.png)
